### PR TITLE
Constrain memory usage in Slurm jobs

### DIFF
--- a/environments/site/inventory/group_vars/all/openhpc.yml
+++ b/environments/site/inventory/group_vars/all/openhpc.yml
@@ -4,5 +4,6 @@
 openhpc_config_extra:
   MpiDefault: pmix
   AccountingStorageEnforce: 'associations,limits,qos,safe'
+  SelectTypeParameters: CR_Core_Memory
 
 openhpc_job_maxtime: '1-0'

--- a/environments/staging/hooks/post.yml
+++ b/environments/staging/hooks/post.yml
@@ -3,3 +3,15 @@
 # environments/site/hooks/pre.yml:
 - name: Import parent hook
   import_playbook: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/../site/hooks/post.yml"
+
+- name: Staging-specific Slurm config
+  hosts: control
+  become: true
+  tags: openhpc
+  tasks:
+    - name: Is demo_user associated
+      ansible.builtin.command: "sacctmgr --json show assoc user=demo_user"
+      register: demo_user_assoc
+    - name: Set Slurm account for demo_user
+      ansible.builtin.command: "sacctmgr --immediate create user name=demo_user defaultaccount=root"
+      when: not (demo_user_assoc.stdout | from_json)["associations"]

--- a/environments/staging/inventory/group_vars/all/openhpc.yml
+++ b/environments/staging/inventory/group_vars/all/openhpc.yml
@@ -1,3 +1,1 @@
 ---
-openhpc_config_extra:
-  MpiDefault: pmix


### PR DESCRIPTION
Fixes isambard-sc/dl-bc5#5

This also now avoids overriding `openhpc_config_extra` in `environments/staging/inventory/group_vars/all/openhpc.yml` as it was doing a complete override, not a merged override. We avoid it by setting the `demo_user` account association in the port hook in staging.