### PR TITLE
Add CPU model features to Slurm

### DIFF
--- a/environments/production/inventory/group_vars/all/openhpc.yml
+++ b/environments/production/inventory/group_vars/all/openhpc.yml
@@ -3,46 +3,92 @@ gpu_gres:
   - conf: "gpu:A100:1"
     file: "/dev/nvidia0"
 
+gen1_features:
+  - cpu_model:epyc-7713
+
+gen2_features:
+  - cpu_model:epyc-9655
+
 openhpc_nodegroups:
   - name: general-compute1
+    features: "{{ gen1_features }}"
   - name: general-compute2
+    features: "{{ gen1_features }}"
   - name: general-compute3
+    features: "{{ gen1_features }}"
   - name: general-compute4
+    features: "{{ gen1_features }}"
   - name: general-compute5
+    features: "{{ gen1_features }}"
   - name: general-compute6
+    features: "{{ gen1_features }}"
   - name: general-gen2-compute9
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute10
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute11
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute12
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute13
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute14
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute15
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute16
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute17
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute18
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute19
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute20
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute21
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute22
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute23
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute24
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute25
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute26
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute27
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute28
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute29
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute30
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute31
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute32
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute33
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute34
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute35
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute36
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute37
+    features: "{{ gen2_features }}"
   - name: general-gen2-compute38
+    features: "{{ gen2_features }}"
   - name: highmem-compute7
+    features: "{{ gen1_features }}"
   - name: highmem-compute8
+    features: "{{ gen1_features }}"
   - name: gpu-gpu1
+    features: "{{ gen1_features }}"
     gres: "{{ gpu_gres }}"
   - name: gpu-gpu2
+    features: "{{ gen1_features }}"
     gres: "{{ gpu_gres }}"


### PR DESCRIPTION
Add the feature `cpu_model:epyc-7713` to the gen 1 CPU nodes, the high-mem nodes, and the GPU nodes; and adds `cpu_model:epyc-9655` to the gen 2 CPU nodes.

Fixes isambard-sc/dl-bc5#4

<details>
<summary>The <code>slurm.conf</code> diff output from <code>ansible-playbook ansible/slurm.yml 
--limit '!vcompute127' --diff --check</code></summary>

```diff
--- before: /etc/slurm/slurm.conf
+++ after: /home/ubuntu/.ansible/tmp/ansible-local-123374vbhipht/tmpwswgu3eg/slurm.conf.j2
@@ -46,161 +46,161 @@

 # COMPUTE NODES
 # nodegroup: general-compute1
-NodeName=vcompute[000-006] Features=nodegroup_general-compute1 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[000-006] Features=nodegroup_general-compute1,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute1 Feature=nodegroup_general-compute1

 # nodegroup: general-compute2
-NodeName=vcompute[007-013] Features=nodegroup_general-compute2 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[007-013] Features=nodegroup_general-compute2,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute2 Feature=nodegroup_general-compute2

 # nodegroup: general-compute3
-NodeName=vcompute[014-020] Features=nodegroup_general-compute3 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[014-020] Features=nodegroup_general-compute3,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute3 Feature=nodegroup_general-compute3

 # nodegroup: general-compute4
-NodeName=vcompute[021-027] Features=nodegroup_general-compute4 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[021-027] Features=nodegroup_general-compute4,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute4 Feature=nodegroup_general-compute4

 # nodegroup: general-compute5
-NodeName=vcompute[028-034] Features=nodegroup_general-compute5 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[028-034] Features=nodegroup_general-compute5,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute5 Feature=nodegroup_general-compute5

 # nodegroup: general-compute6
-NodeName=vcompute[035-040] Features=nodegroup_general-compute6 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[035-040] Features=nodegroup_general-compute6,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115551 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-compute6 Feature=nodegroup_general-compute6

 # nodegroup: general-gen2-compute9
-NodeName=vcompute[041-051] Features=nodegroup_general-gen2-compute9 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[041-051] Features=nodegroup_general-gen2-compute9,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute9 Feature=nodegroup_general-gen2-compute9

 # nodegroup: general-gen2-compute10
-NodeName=vcompute[052-062] Features=nodegroup_general-gen2-compute10 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[052-062] Features=nodegroup_general-gen2-compute10,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute10 Feature=nodegroup_general-gen2-compute10

 # nodegroup: general-gen2-compute11
-NodeName=vcompute[063-073] Features=nodegroup_general-gen2-compute11 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[063-073] Features=nodegroup_general-gen2-compute11,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute11 Feature=nodegroup_general-gen2-compute11

 # nodegroup: general-gen2-compute12
-NodeName=vcompute[074-084] Features=nodegroup_general-gen2-compute12 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[074-084] Features=nodegroup_general-gen2-compute12,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute12 Feature=nodegroup_general-gen2-compute12

 # nodegroup: general-gen2-compute13
-NodeName=vcompute[085-095] Features=nodegroup_general-gen2-compute13 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[085-095] Features=nodegroup_general-gen2-compute13,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute13 Feature=nodegroup_general-gen2-compute13

 # nodegroup: general-gen2-compute14
 NodeSet=nodegroup_general-gen2-compute14 Feature=nodegroup_general-gen2-compute14

 # nodegroup: general-gen2-compute15
-NodeName=vcompute[107-117] Features=nodegroup_general-gen2-compute15 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[107-117] Features=nodegroup_general-gen2-compute15,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute15 Feature=nodegroup_general-gen2-compute15

 # nodegroup: general-gen2-compute16
-NodeName=vcompute[118-128] Features=nodegroup_general-gen2-compute16 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[118-128] Features=nodegroup_general-gen2-compute16,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute16 Feature=nodegroup_general-gen2-compute16

 # nodegroup: general-gen2-compute17
-NodeName=vcompute[131-135,137-139] Features=nodegroup_general-gen2-compute17 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[131-135,137-139] Features=nodegroup_general-gen2-compute17,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute17 Feature=nodegroup_general-gen2-compute17

 # nodegroup: general-gen2-compute18
-NodeName=vcompute[140-145,147-148,150] Features=nodegroup_general-gen2-compute18 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[140-145,147-148,150] Features=nodegroup_general-gen2-compute18,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute18 Feature=nodegroup_general-gen2-compute18

 # nodegroup: general-gen2-compute19
-NodeName=vcompute[151-157,159-161] Features=nodegroup_general-gen2-compute19 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[151-157,159-161] Features=nodegroup_general-gen2-compute19,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute19 Feature=nodegroup_general-gen2-compute19

 # nodegroup: general-gen2-compute20
-NodeName=vcompute[162-172] Features=nodegroup_general-gen2-compute20 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[162-172] Features=nodegroup_general-gen2-compute20,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute20 Feature=nodegroup_general-gen2-compute20

 # nodegroup: general-gen2-compute21
-NodeName=vcompute[173-183] Features=nodegroup_general-gen2-compute21 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[173-183] Features=nodegroup_general-gen2-compute21,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute21 Feature=nodegroup_general-gen2-compute21

 # nodegroup: general-gen2-compute22
-NodeName=vcompute[184-194] Features=nodegroup_general-gen2-compute22 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[184-194] Features=nodegroup_general-gen2-compute22,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute22 Feature=nodegroup_general-gen2-compute22

 # nodegroup: general-gen2-compute23
-NodeName=vcompute[195-205] Features=nodegroup_general-gen2-compute23 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[195-205] Features=nodegroup_general-gen2-compute23,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute23 Feature=nodegroup_general-gen2-compute23

 # nodegroup: general-gen2-compute24
-NodeName=vcompute[206-216] Features=nodegroup_general-gen2-compute24 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[206-216] Features=nodegroup_general-gen2-compute24,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute24 Feature=nodegroup_general-gen2-compute24

 # nodegroup: general-gen2-compute25
-NodeName=vcompute[217-227] Features=nodegroup_general-gen2-compute25 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[217-227] Features=nodegroup_general-gen2-compute25,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute25 Feature=nodegroup_general-gen2-compute25

 # nodegroup: general-gen2-compute26
-NodeName=vcompute[228-238] Features=nodegroup_general-gen2-compute26 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[228-238] Features=nodegroup_general-gen2-compute26,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute26 Feature=nodegroup_general-gen2-compute26

 # nodegroup: general-gen2-compute27
-NodeName=vcompute[239-249] Features=nodegroup_general-gen2-compute27 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[239-249] Features=nodegroup_general-gen2-compute27,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute27 Feature=nodegroup_general-gen2-compute27

 # nodegroup: general-gen2-compute28
 NodeSet=nodegroup_general-gen2-compute28 Feature=nodegroup_general-gen2-compute28

 # nodegroup: general-gen2-compute29
-NodeName=vcompute[261-271] Features=nodegroup_general-gen2-compute29 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[261-271] Features=nodegroup_general-gen2-compute29,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute29 Feature=nodegroup_general-gen2-compute29

 # nodegroup: general-gen2-compute30
-NodeName=vcompute[272-282] Features=nodegroup_general-gen2-compute30 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[272-282] Features=nodegroup_general-gen2-compute30,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute30 Feature=nodegroup_general-gen2-compute30

 # nodegroup: general-gen2-compute31
-NodeName=vcompute[283-293] Features=nodegroup_general-gen2-compute31 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[283-293] Features=nodegroup_general-gen2-compute31,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute31 Feature=nodegroup_general-gen2-compute31

 # nodegroup: general-gen2-compute32
-NodeName=vcompute[294-304] Features=nodegroup_general-gen2-compute32 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[294-304] Features=nodegroup_general-gen2-compute32,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute32 Feature=nodegroup_general-gen2-compute32

 # nodegroup: general-gen2-compute33
-NodeName=vcompute[305-315] Features=nodegroup_general-gen2-compute33 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[305-315] Features=nodegroup_general-gen2-compute33,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute33 Feature=nodegroup_general-gen2-compute33

 # nodegroup: general-gen2-compute34
-NodeName=vcompute[316-326] Features=nodegroup_general-gen2-compute34 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[316-326] Features=nodegroup_general-gen2-compute34,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute34 Feature=nodegroup_general-gen2-compute34

 # nodegroup: general-gen2-compute35
-NodeName=vcompute[327-337] Features=nodegroup_general-gen2-compute35 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[327-337] Features=nodegroup_general-gen2-compute35,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute35 Feature=nodegroup_general-gen2-compute35

 # nodegroup: general-gen2-compute36
-NodeName=vcompute[338-348] Features=nodegroup_general-gen2-compute36 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[338-348] Features=nodegroup_general-gen2-compute36,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute36 Feature=nodegroup_general-gen2-compute36

 # nodegroup: general-gen2-compute37
-NodeName=vcompute[349-359] Features=nodegroup_general-gen2-compute37 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[349-359] Features=nodegroup_general-gen2-compute37,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute37 Feature=nodegroup_general-gen2-compute37

 # nodegroup: general-gen2-compute38
-NodeName=vcompute[360-370] Features=nodegroup_general-gen2-compute38 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
+NodeName=vcompute[360-370] Features=nodegroup_general-gen2-compute38,cpu_model:epyc-9655 State=UNKNOWN RealMemory=115550 Sockets=2 CoresPerSocket=8 ThreadsPerCore=2
 NodeSet=nodegroup_general-gen2-compute38 Feature=nodegroup_general-gen2-compute38

 # nodegroup: highmem-compute7
-NodeName=vhighmem[000-001] Features=nodegroup_highmem-compute7 State=UNKNOWN RealMemory=405850 Sockets=2 CoresPerSocket=28 ThreadsPerCore=1
+NodeName=vhighmem[000-001] Features=nodegroup_highmem-compute7,cpu_model:epyc-7713 State=UNKNOWN RealMemory=405850 Sockets=2 CoresPerSocket=28 ThreadsPerCore=1
 NodeSet=nodegroup_highmem-compute7 Feature=nodegroup_highmem-compute7

 # nodegroup: highmem-compute8
-NodeName=vhighmem[002-003] Features=nodegroup_highmem-compute8 State=UNKNOWN RealMemory=405850 Sockets=2 CoresPerSocket=28 ThreadsPerCore=1
+NodeName=vhighmem[002-003] Features=nodegroup_highmem-compute8,cpu_model:epyc-7713 State=UNKNOWN RealMemory=405850 Sockets=2 CoresPerSocket=28 ThreadsPerCore=1
 NodeSet=nodegroup_highmem-compute8 Feature=nodegroup_highmem-compute8

 # nodegroup: gpu-gpu1
-NodeName=vgpu[000-001] Features=nodegroup_gpu-gpu1 State=UNKNOWN RealMemory=115552 Sockets=2 CoresPerSocket=8 ThreadsPerCore=1  Gres=gpu:A100:1
+NodeName=vgpu[000-001] Features=nodegroup_gpu-gpu1,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115552 Sockets=2 CoresPerSocket=8 ThreadsPerCore=1  Gres=gpu:A100:1
 NodeSet=nodegroup_gpu-gpu1 Feature=nodegroup_gpu-gpu1

 # nodegroup: gpu-gpu2
-NodeName=vgpu[002-003] Features=nodegroup_gpu-gpu2 State=UNKNOWN RealMemory=115552 Sockets=2 CoresPerSocket=8 ThreadsPerCore=1  Gres=gpu:A100:1
+NodeName=vgpu[002-003] Features=nodegroup_gpu-gpu2,cpu_model:epyc-7713 State=UNKNOWN RealMemory=115552 Sockets=2 CoresPerSocket=8 ThreadsPerCore=1  Gres=gpu:A100:1
 NodeSet=nodegroup_gpu-gpu2 Feature=nodegroup_gpu-gpu2
```

</details>