### PR TITLE
Updates and fixes for Slurm controlled rebuild

### DIFF
--- a/ansible/roles/openportal/tasks/main.yml
+++ b/ansible/roles/openportal/tasks/main.yml
@@ -7,11 +7,17 @@
   ansible.builtin.copy:
     src: "{{ openportal_binaries_dir }}/"
     dest: "/usr/local/bin"
+    mode: "u=rwx,g=rx,o=rx"
+    owner: "root"
+    group: "root"
 
 - name: Create OpenPortal config directory
   ansible.builtin.file:
     state: directory
     path: "/etc/openportal/"
+    mode: "u=rwx,g=,o="
+    owner: "root"
+    group: "root"
 
 - name: Setup Openportal {{ openportal_service.name }} service
   ansible.builtin.include_tasks: service.yml

--- a/ansible/roles/openportal/tasks/service.yml
+++ b/ansible/roles/openportal/tasks/service.yml
@@ -4,6 +4,9 @@
   ansible.builtin.template:
     src: "service.j2"
     dest: "/etc/systemd/system/{{ openportal_service.name }}.service"
+    mode: "u=rw,g=r,o=r"
+    owner: "root"
+    group: "root"
   register: openportal_service_files
   notify: "Restart OpenPortal services"
 
@@ -11,6 +14,9 @@
   ansible.builtin.file:
     state: directory
     path: "/etc/openportal/{{ openportal_service.name }}"
+    mode: "u=rwx,g=,o="
+    owner: "root"
+    group: "root"
 
 - name: "{{ openportal_service.name }} : Install config file"
   ansible.builtin.template:

--- a/environments/production/tofu/main.tf
+++ b/environments/production/tofu/main.tf
@@ -53,6 +53,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-compute2 = {
@@ -82,6 +83,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-compute3 = {
@@ -111,6 +113,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-compute4 = {
@@ -140,6 +143,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-compute5 = {
@@ -169,6 +173,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-compute6 = {
@@ -197,6 +202,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute9 = {
@@ -230,6 +236,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute10 = {
@@ -263,6 +270,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute11 = {
@@ -296,6 +304,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute12 = {
@@ -329,6 +338,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute13 = {
@@ -362,6 +372,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
 #      general-gen2-compute14 = {
@@ -428,6 +439,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute16 = {
@@ -461,6 +473,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute17 = {
@@ -494,6 +507,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute18 = {
@@ -527,6 +541,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute19 = {
@@ -560,6 +575,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute20 = {
@@ -593,6 +609,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute21 = {
@@ -626,6 +643,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute22 = {
@@ -659,6 +677,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute23 = {
@@ -692,6 +711,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute24 = {
@@ -725,6 +745,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute25 = {
@@ -758,6 +779,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute26 = {
@@ -791,6 +813,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute27 = {
@@ -824,6 +847,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       # general-gen2-compute28 = {
@@ -890,6 +914,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute30 = {
@@ -923,6 +948,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute31 = {
@@ -956,6 +982,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute32 = {
@@ -989,6 +1016,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute33 = {
@@ -1022,6 +1050,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute34 = {
@@ -1055,6 +1084,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute35 = {
@@ -1088,6 +1118,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute36 = {
@@ -1121,6 +1152,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute37 = {
@@ -1154,6 +1186,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
       general-gen2-compute38 = {
@@ -1187,6 +1220,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
      gpu-gpu1 = {
@@ -1210,6 +1244,7 @@ module "cluster" {
            "manila",
            "basic_users",
            "eessi",
+           "sssd",
          ]
      }
      gpu-gpu2 = {
@@ -1233,6 +1268,7 @@ module "cluster" {
            "manila",
            "basic_users",
            "eessi",
+           "sssd",
          ]
      }
      highmem-compute7 = {
@@ -1256,6 +1292,7 @@ module "cluster" {
            "manila",
            "basic_users",
            "eessi",
+           "sssd",
          ]
      }
      highmem-compute8 = {
@@ -1279,6 +1316,7 @@ module "cluster" {
            "manila",
            "basic_users",
            "eessi",
+           "sssd",
          ]
      }
     }

--- a/environments/production/tofu/main.tf
+++ b/environments/production/tofu/main.tf
@@ -406,6 +406,7 @@ module "cluster" {
 #            "manila",
 #            "basic_users",
 #            "eessi",
+#            "sssd",
 #          ]
 #      }
       general-gen2-compute15 = {
@@ -881,6 +882,7 @@ module "cluster" {
       #       "manila",
       #       "basic_users",
       #       "eessi",
+      #       "sssd",
       #     ]
       # }
       general-gen2-compute29 = {

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -115,7 +115,7 @@ variable "login" {
 variable "cluster_image_id" {
   type        = string
   description = "ID of default image for the cluster"
-  default     = "671582eb-5bce-4828-9e45-13af767914dc"   # openhpc-251119-1408-0a3c2165
+  default     = "5fca59f9-0b6b-4c6d-a437-7a823cefef7d"   # openhpc-260115-1548-0c9203c5
 }
 
 variable "compute" {

--- a/environments/staging/tofu/main.tf
+++ b/environments/staging/tofu/main.tf
@@ -53,6 +53,7 @@ module "cluster" {
             "manila",
             "basic_users",
             "eessi",
+            "sssd",
           ]
       }
     }


### PR DESCRIPTION
This PR updates configuration issues identified during an attempt to rebuild the staging cluster on 2025-01-15 for the latest commit to the `bristol/main` branch (0c9203c5cde486274fc9e29d9ad9a0265639e507)

* Fix permissions on files installed by OpenPortal role
  * For the binaries, these need to be explicitly set as executable
* Add `"sssd"` to `compute_init_enable` in `tofu` configuration to enable SSSD functionality on node boot for Slurm controlled rebuild
* Update `image_id` to use latest node image build

Further changes may be needed since we were unable to access LDAP directory information from the staging cluster login node after rebuilding the login + control nodes via `tofu` and running the `site.yml` playbook.