### PR TITLE
Don't use LDAP domain discovery

### DIFF
--- a/environments/site/files/sssd.conf.j2
+++ b/environments/site/files/sssd.conf.j2
@@ -9,7 +9,8 @@ filter_groups = root
 
 [domain/acrc.bris.ac.uk]
 id_provider = ldap
-dns_discovery_domain = dl-auth.acrc.bris.ac.uk
+# dns_discovery_domain = dl-auth.acrc.bris.ac.uk
+ldap_uri = ldaps://dl-auth.acrc.bris.ac.uk
 ldap_tls_cacert = /etc/sssd/dl-auth.acrc.bris.ac.uk.cert
 ldap_search_base = cn=accounts,dc=acrc,dc=bris,dc=ac,dc=uk
 ldap_user_search_base = cn=accounts,dc=acrc,dc=bris,dc=ac,dc=uk?subtree?(|(memberOf=cn=bc5adms,cn=groups,cn=accounts,dc=acrc,dc=bris,dc=ac,dc=uk)(memberOf=cn=bc5usrs,cn=groups,cn=accounts,dc=acrc,dc=bris,dc=ac,dc=uk)(memberOf=cn=bc5srvs,cn=groups,cn=accounts,dc=acrc,dc=bris,dc=ac,dc=uk))
@@ -19,6 +20,7 @@ entry_cache_timeout = 60
 ldap_user_ssh_public_key = ipaSshPubKey
 ldap_default_bind_dn = uid=ldap,cn=sysaccounts,cn=etc,dc=acrc,dc=bris,dc=ac,dc=uk
 ldap_default_authtok = {{ vault_freeipa_ldap_bind_password }}
+ldap_ignore_unreadable_references = true
 
 sudo_provider = ldap
 ldap_sudo_search_base = ou=sudoers,dc=acrc,dc=bris,dc=ac,dc=uk


### PR DESCRIPTION
The automatic DNS service discovery was not working. How this was working before, I'm not sure; but I can only guess there was some DNS caching happening from some of my earlier tests - that or ITS have made some small change. Explicitly setting the domain will work fine and it probably more predictable in the long-run.

I also set `ldap_ignore_unreadable_references` as I was seeing some errors in the `/var/log/sssd/sssd_acrc.bris.ac.uk.log` log.

I have applied these changes manually to the staging login node, so a good test would be to apply these changes using Ansible to the control node and see if it works.