### PR TITLE
Disable nightly run of CI test

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -1,8 +1,8 @@
 name: Cleanup CI clusters
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 21 * * *'  # Run at 9PM - image sync runs at midnight
+  #schedule:
+  #  - cron: '0 21 * * *'  # Run at 9PM - image sync runs at midnight
 
 permissions:
   contents: read


### PR DESCRIPTION
This test is failing every night end emailing me and I don't want to return from leave to 90 emails.