### PR TITLE
Fixes following Slurm appliance rebuild attempt on 2026-01-29

### DIFF
--- a/ansible/roles/openportal/templates/config.toml.j2
+++ b/ansible/roles/openportal/templates/config.toml.j2
@@ -50,3 +50,7 @@ data = "{{ client.key.outer }}"
 {{ key }} = "{{ value }}"
 {% endfor %}
 {% endif %}
+{% if openportal_service.config.custom is defined %}
+
+{{ openportal_service.config.custom }}
+{% endif %}

--- a/ansible/roles/openportal/templates/config.toml.j2
+++ b/ansible/roles/openportal/templates/config.toml.j2
@@ -5,6 +5,12 @@ name = "{{ openportal_service.config.name }}"
 url = "ws://{{ openportal_service.config.hostname }}:{{ openportal_service.config.port }}/"
 ip = "{{ openportal_service.config.ip }}"
 port = {{ openportal_service.config.port }}
+{% if openportal_service.config.servers is undefined %}
+servers = []
+{% endif %}
+{% if openportal_service.config.clients is undefined %}
+clients = []
+{% endif %}
 
 {% if openportal_service.config.servers is defined %}
 {% for server in openportal_service.config.servers %}
@@ -19,8 +25,6 @@ data = "{{ server.key.inner }}"
 [service.servers.outer_key]
 data = "{{ server.key.outer }}"
 {% endfor %}
-{% else %}
-servers = []
 {% endif %}
 
 {% if openportal_service.config.clients is defined %}
@@ -38,8 +42,6 @@ data = "{{ client.key.inner }}"
 [service.clients.outer_key]
 data = "{{ client.key.outer }}"
 {% endfor %}
-{% else %}
-clients = []
 {% endif %}
 
 [extras]

--- a/environments/production/tofu/main.tf
+++ b/environments/production/tofu/main.tf
@@ -44,17 +44,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
 	    "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-compute2 = {
           nodes: [
@@ -74,17 +74,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-compute3 = {
           nodes: [
@@ -104,17 +104,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-compute4 = {
           nodes: [
@@ -134,17 +134,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-compute5 = {
           nodes: [
@@ -164,17 +164,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-compute6 = {
           nodes: [
@@ -193,17 +193,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute9 = {
           nodes: [
@@ -227,17 +227,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute10 = {
           nodes: [
@@ -261,17 +261,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute11 = {
           nodes: [
@@ -295,17 +295,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute12 = {
           nodes: [
@@ -329,17 +329,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute13 = {
           nodes: [
@@ -363,17 +363,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
 #      general-gen2-compute14 = {
 #          nodes: [
@@ -431,17 +431,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute16 = {
           nodes: [
@@ -465,17 +465,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute17 = {
           nodes: [
@@ -499,17 +499,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute18 = {
           nodes: [
@@ -533,17 +533,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute19 = {
           nodes: [
@@ -567,17 +567,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute20 = {
           nodes: [
@@ -601,17 +601,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute21 = {
           nodes: [
@@ -635,17 +635,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute22 = {
           nodes: [
@@ -669,17 +669,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute23 = {
           nodes: [
@@ -703,17 +703,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute24 = {
           nodes: [
@@ -737,17 +737,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute25 = {
           nodes: [
@@ -771,17 +771,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute26 = {
           nodes: [
@@ -805,17 +805,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute27 = {
           nodes: [
@@ -839,17 +839,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       # general-gen2-compute28 = {
       #     nodes: [
@@ -907,17 +907,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute30 = {
           nodes: [
@@ -941,17 +941,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute31 = {
           nodes: [
@@ -975,17 +975,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute32 = {
           nodes: [
@@ -1009,17 +1009,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute33 = {
           nodes: [
@@ -1043,17 +1043,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute34 = {
           nodes: [
@@ -1077,17 +1077,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute35 = {
           nodes: [
@@ -1111,17 +1111,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute36 = {
           nodes: [
@@ -1145,17 +1145,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute37 = {
           nodes: [
@@ -1179,17 +1179,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
       general-gen2-compute38 = {
           nodes: [
@@ -1213,17 +1213,17 @@ module "cluster" {
             "slurm-production-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
      gpu-gpu1 = {
          nodes: [
@@ -1237,17 +1237,17 @@ module "cluster" {
            "slurm-production": "direct"
            "external-ceph": "direct"
          }
-         ignore_image_changes: true
-         compute_init_enable = [
-           "compute",
-           "etc_hosts",
-           "tuned",
-           "nfs",
-           "manila",
-           "basic_users",
-           "eessi",
-           "sssd",
-         ]
+#         ignore_image_changes: true
+#         compute_init_enable = [
+#           "compute",
+#           "etc_hosts",
+#           "tuned",
+#           "nfs",
+#           "manila",
+#           "basic_users",
+#           "eessi",
+#           "sssd",
+#         ]
      }
      gpu-gpu2 = {
          nodes: [
@@ -1261,17 +1261,17 @@ module "cluster" {
            "slurm-production": "direct"
            "external-ceph": "direct"
          }
-         ignore_image_changes: true
-         compute_init_enable = [
-           "compute",
-           "etc_hosts",
-           "tuned",
-           "nfs",
-           "manila",
-           "basic_users",
-           "eessi",
-           "sssd",
-         ]
+#         ignore_image_changes: true
+#         compute_init_enable = [
+#           "compute",
+#           "etc_hosts",
+#           "tuned",
+#           "nfs",
+#           "manila",
+#           "basic_users",
+#           "eessi",
+#           "sssd",
+#         ]
      }
      highmem-compute7 = {
          nodes: [
@@ -1285,17 +1285,17 @@ module "cluster" {
            "slurm-production": "direct"
            "external-ceph": "direct"
          }
-         ignore_image_changes: true
-         compute_init_enable = [
-           "compute",
-           "etc_hosts",
-           "tuned",
-           "nfs",
-           "manila",
-           "basic_users",
-           "eessi",
-           "sssd",
-         ]
+#         ignore_image_changes: true
+#         compute_init_enable = [
+#           "compute",
+#           "etc_hosts",
+#           "tuned",
+#           "nfs",
+#           "manila",
+#           "basic_users",
+#           "eessi",
+#           "sssd",
+#         ]
      }
      highmem-compute8 = {
          nodes: [
@@ -1309,17 +1309,17 @@ module "cluster" {
            "slurm-production": "direct"
            "external-ceph": "direct"
          }
-         ignore_image_changes: true
-         compute_init_enable = [
-           "compute",
-           "etc_hosts",
-           "tuned",
-           "nfs",
-           "manila",
-           "basic_users",
-           "eessi",
-           "sssd",
-         ]
+#         ignore_image_changes: true
+#         compute_init_enable = [
+#           "compute",
+#           "etc_hosts",
+#           "tuned",
+#           "nfs",
+#           "manila",
+#           "basic_users",
+#           "eessi",
+#           "sssd",
+#         ]
      }
     }
 

--- a/environments/site/inventory/group_vars/all/openportal.yml
+++ b/environments/site/inventory/group_vars/all/openportal.yml
@@ -50,7 +50,7 @@ openportal_services:
       ip: "127.0.0.1"
       port: 8071
       servers:
-        - name: "cluster"
+        - name: "clusters"
           url: "ws://localhost:8082"
           zone: "dl"
           key: "{{ openportal_keys.op_dl_clusters_to_op_dl_clusters_bc5 }}"

--- a/environments/site/inventory/group_vars/all/openportal.yml
+++ b/environments/site/inventory/group_vars/all/openportal.yml
@@ -128,4 +128,5 @@ openportal_services:
         freeipa-password: "{{ openportal_freeipa_password }}"
         instance-groups: "bc5@dl-clusters-bc5:bc5usrs"
         freeipa-server: "https://dl-auth.acrc.bris.ac.uk"
-
+      custom: |
+        [service.encryption.Simple]

--- a/environments/site/inventory/group_vars/all/openportal.yml
+++ b/environments/site/inventory/group_vars/all/openportal.yml
@@ -108,7 +108,7 @@ openportal_services:
         # These numbers are chosen so that using all of a "normal" node is
         # charged as 1 node hour, while using all of the "high memory" node
         # is charged as 2 node hours
-        slurm-default-node: '{ "cpus": 32, "mem": 214199}'
+        slurm-default-node: '{ \"cpus\": 32, \"mem\": 214199}'
   - name: "op-dl-freeipa"
     binary: "/usr/local/bin/op-freeipa"
     extra: 'Environment="OPENPORTAL_ALLOW_INVALID_SSL_CERTS=true"'

--- a/environments/staging/tofu/main.tf
+++ b/environments/staging/tofu/main.tf
@@ -44,17 +44,17 @@ module "cluster" {
             "slurm-staging-rdma-net": "direct"
             "external-ceph": "direct"
           }
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
+#          ignore_image_changes: true
+#          compute_init_enable = [
+#            "compute",
+#            "etc_hosts",
+#            "tuned",
+#            "nfs",
+#            "manila",
+#            "basic_users",
+#            "eessi",
+#            "sssd",
+#          ]
       }
     }
 


### PR DESCRIPTION
* Disable `compute-init` / Slurm controlled rebuild for staging and prod
* Update OpenPortal role and config to fix issues with templated TOML config files

Tested in a full rebuild of the staging cluster (starting after `tofu destroy` of any existing infrastructure).
 
* [x] Checked that templated OpenPortal configuration files match expected versions
* [x] Checked that `compute-init` playbook is skipped on compute nodes (<https://github.com/ACRC/ansible-slurm-appliance/blob/160d1fc0e49b703ac681da4ce24806a578c81d39/ansible/roles/compute_init/files/compute-init.yml#L50>) and `ansible-init.done` signal file is present (<https://github.com/stackhpc/ansible-role-linux-ansible-init/blob/d6ce5dc5bbce4dd672f6513d4b3c86dc805775aa/files/ansible-init.service#L11>).