### PR TITLE
Backport change to deactivate trivy 

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -47,7 +47,6 @@ jobs:
       OS_CLOUD: openstack
       CI_CLOUD: ${{ github.event.inputs.ci_cloud == 'default' && vars.CI_CLOUD || github.event.inputs.ci_cloud }}
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
-      LEAFCLOUD_PULP_PASSWORD: ${{ secrets.LEAFCLOUD_PULP_PASSWORD }}
       PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,10 +141,10 @@ jobs:
     uses: ./.github/workflows/extra.yml
     secrets: inherit
 
-  trivyscan:
-    name: Trivy scan image for vulnerabilities
-    needs: files_changed
-    if: |
-      needs.files_changed.outputs.trivyscan == 'true' || github.event_name != 'pull_request'
-    uses: ./.github/workflows/trivyscan.yml
-    secrets: inherit
+  # trivyscan:
+  #   name: Trivy scan image for vulnerabilities
+  #   needs: files_changed
+  #   if: |
+  #     needs.files_changed.outputs.trivyscan == 'true' || github.event_name != 'pull_request'
+  #   uses: ./.github/workflows/trivyscan.yml
+  #   secrets: inherit

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -42,7 +42,6 @@ jobs:
       OS_CLOUD: openstack
       CI_CLOUD: ${{ github.event.inputs.ci_cloud || vars.CI_CLOUD }}
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
-      LEAFCLOUD_PULP_PASSWORD: ${{ secrets.LEAFCLOUD_PULP_PASSWORD }}
       PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:

--- a/.github/workflows/trivyscan.deactivated
+++ b/.github/workflows/trivyscan.deactivated
@@ -104,7 +104,7 @@ jobs:
         run: sudo guestmount -a /mnt/images/${{ steps.manifest.outputs.image-name }}.qcow2 -i --ro -o allow_other './${{ steps.manifest.outputs.image-name }}'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7
         with:
           scan-type: fs
           scan-ref: "${{ steps.manifest.outputs.image-name }}"
@@ -124,7 +124,7 @@ jobs:
           category: "${{ matrix.build }}"
 
       - name: Fail if scan has CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7
         with:
           scan-type: fs
           scan-ref: "${{ steps.manifest.outputs.image-name }}"

--- a/environments/.stackhpc/inventory/group_vars/builder.yml
+++ b/environments/.stackhpc/inventory/group_vars/builder.yml
@@ -3,13 +3,6 @@
 sssd_install_ldap: true # include sssd-ldap package in fatimage
 # update_enable: false # Can uncomment for speed debugging non-update related build issues
 
-# Uncomment below to use CI pulp servers
-
-# pulp_server_config:
-#   LEAFCLOUD:
-#     url: http://192.168.10.157:8080
-#     password: lookup('env','LEAFCLOUD_PULP_PASSWORD')
-
 # appliances_pulp_url: "{{ pulp_server_config[lookup('env','CI_CLOUD')].url }}"
 # pulp_site_password: "{{ pulp_server_config[lookup('env','CI_CLOUD')].password }}"
 


### PR DESCRIPTION
Cherry-picked stackhpc/ansible-slurm-appliance#934 to deactivate Trivy workflow due to supply chain attack. See <https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23>.