### PR TITLE
Add `ksh` and `lsb_release` from EPEL 9 to node image

### DIFF
--- a/environments/site/inventory/group_vars/all/defaults.yml
+++ b/environments/site/inventory/group_vars/all/defaults.yml
@@ -9,5 +9,6 @@ appliances_extra_packages_other:
   - vim-enhanced
   - emacs
   - bc
+  - lsb_release
 
 openhpc_ram_multiplier: 0.9

--- a/environments/site/inventory/group_vars/all/defaults.yml
+++ b/environments/site/inventory/group_vars/all/defaults.yml
@@ -10,5 +10,6 @@ appliances_extra_packages_other:
   - emacs
   - bc
   - lsb_release
+  - ksh
 
 openhpc_ram_multiplier: 0.9

--- a/environments/staging/inventory/group_vars/all/defaults.yml
+++ b/environments/staging/inventory/group_vars/all/defaults.yml
@@ -1,4 +1,6 @@
 # Uncomment to allow Ark credentials to be used outside of build context
 # This is useful to test installing new packages without needing to create
 # a new image
-dnf_repos_allow_insecure_creds: true
+# NOTE: You also need to uncomment the line adding group cluster as a child
+#   of group extra_packages in environments/staging/inventory/groups
+#dnf_repos_allow_insecure_creds: true

--- a/environments/staging/inventory/group_vars/all/defaults.yml
+++ b/environments/staging/inventory/group_vars/all/defaults.yml
@@ -1,0 +1,4 @@
+# Uncomment to allow Ark credentials to be used outside of build context
+# This is useful to test installing new packages without needing to create
+# a new image
+dnf_repos_allow_insecure_creds: true

--- a/environments/staging/inventory/group_vars/all/z_partitions.yml
+++ b/environments/staging/inventory/group_vars/all/z_partitions.yml
@@ -1,13 +1,13 @@
 openhpc_partitions:
     - name: general
       nodegroups:
-        - general-compute22
+        #- general-compute22
         - general-compute23
       partition_params:
         DefaultTime: 15
     - name: rebuild
       nodegroups:
-        - general-compute22
+        #- general-compute22
         - general-compute23
       default: NO
       maxtime: 30

--- a/environments/staging/inventory/groups
+++ b/environments/staging/inventory/groups
@@ -115,6 +115,7 @@ cluster
 [extra_packages:children]
 # Hosts to install specified additional packages on
 builder
+cluster
 
 [cacerts]
 # Hosts to configure CA certificates and trusts on

--- a/environments/staging/inventory/groups
+++ b/environments/staging/inventory/groups
@@ -115,7 +115,10 @@ cluster
 [extra_packages:children]
 # Hosts to install specified additional packages on
 builder
-cluster
+# Uncomment cluster group to allow packages to be installed outside of image build
+# NOTE: You also need to uncomment the line setting dnf_repos_allow_insecure_creds
+#   to true in environments/staging/inventory/group_vars/all/defaults.yml
+#cluster
 
 [cacerts]
 # Hosts to configure CA certificates and trusts on

--- a/environments/staging/tofu/main.tf
+++ b/environments/staging/tofu/main.tf
@@ -30,13 +30,13 @@ module "cluster" {
           nodes: [
 		"stagingcompute000",
 		"stagingcompute001",
-                "stagingcompute002",
-                "stagingcompute003",
-                "stagingcompute004",
-                "stagingcompute005",
-                "stagingcompute006",
-                "stagingcompute007",
-		"stagingcompute008",
+                #"stagingcompute002",
+                #"stagingcompute003",
+                #"stagingcompute004",
+                #"stagingcompute005",
+                #"stagingcompute006",
+                #"stagingcompute007",
+		#"stagingcompute008",
 	  ]
           flavor: "hpc.v2.32cpu.128ram" # TODO: make this a 32cpu gen1 once there's space
           hypervisor_hostname = "compute23"
@@ -52,24 +52,24 @@ module "cluster" {
             "sssd",
           ]
       }
-      general-compute22 = {
-          nodes: [
-		"stagingcompute009",
-	  ]
-          flavor: "hpc.v2.32cpu.128ram" # TODO: make this a 32cpu gen1 once there's space
-          hypervisor_hostname = "compute22"
-          ignore_image_changes: true
-          compute_init_enable = [
-            "compute",
-            "etc_hosts",
-            "tuned",
-            "nfs",
-            "manila",
-            "basic_users",
-            "eessi",
-            "sssd",
-          ]
-      }
+      #general-compute22 = {
+      #    nodes: [
+      #  	"stagingcompute009",
+      #    ]
+      #    flavor: "hpc.v2.32cpu.128ram" # TODO: make this a 32cpu gen1 once there's space
+      #    hypervisor_hostname = "compute22"
+      #    ignore_image_changes: true
+      #    compute_init_enable = [
+      #      "compute",
+      #      "etc_hosts",
+      #      "tuned",
+      #      "nfs",
+      #      "manila",
+      #      "basic_users",
+      #      "eessi",
+      #      "sssd",
+      #    ]
+      #}
     }
 
     login = {


### PR DESCRIPTION
This PR replaces #41, which had the wrong base branch.

This has been tested in staging cluster without a new node image build.

```shell-session
staging/ ((venv) ) ubuntu@stackhpc-slurm-control-host:~/ansible-slurm-appliance/environments/staging/tofu$ tofu destroy
[…]
Destroy complete! Resources: 19 destroyed.

staging/ ((venv) ) ubuntu@stackhpc-slurm-control-host:~/ansible-slurm-appliance/environments/staging/tofu$ tofu apply
[…]
Apply complete! Resources: 19 added, 0 changed, 0 destroyed.

staging/ ((venv) ) ubuntu@stackhpc-slurm-control-host:~/ansible-slurm-appliance$ ansible-playbook ansible/site.yml

PLAY RECAP ********************************************************************************************************
control                    : ok=211  changed=99   unreachable=0    failed=0    skipped=89   rescued=0    ignored=0   
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
stagingcompute000          : ok=99   changed=47   unreachable=0    failed=0    skipped=67   rescued=0    ignored=0   
stagingcompute001          : ok=95   changed=43   unreachable=0    failed=0    skipped=67   rescued=0    ignored=0   
staginglogin               : ok=169  changed=85   unreachable=0    failed=0    skipped=63   rescued=0    ignored=0 

[rocky@staginglogin ~]$ dnf list --installed lsb_release
Installed Packages
lsb_release.noarch                                         3.2-2.el9                                          @epel

[rocky@staginglogin ~]$ lsb_release --all
LSB Version:    n/a
Distributor ID: RockyLinux
Description:    Rocky Linux 9.7 (Blue Onyx)
Release:        9.7
Codename:       n/a

[rocky@staginglogin ~]$ sudo su -l demo_user
[demo_user@staginglogin ~]$ srun -n1 -t1 lsb_release --all
LSB Version:    n/a
Distributor ID: RockyLinux
Description:    Rocky Linux 9.7 (Blue Onyx)
Release:        9.7
Codename:       n/a
```

I have added `dnf_repos_allow_insecure_creds: true` as a commented variable in for the staging cluster. I uncommented this to allow testing of package installs without needing to build an image. Similarly, I have added a commented line to add the `cluster` group as a child of the `extra_packages` group for staging (this needs to uncommented to allow installing of packages without an image build).

This PR also includes some changes to `main.tf` and `z_partitions.yml` to reduce the size of the staging cluster to 2 VMs on compute23.

